### PR TITLE
Added the system v packages as suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,8 @@
     "suggest": {
         "ext-proctitle": "*",
         "ext-pcntl": "*",
+        "ext-sysvsem": "Required for using the Semaphore class",
+        "ext-sysvshm": "Required for using the SharedMemory class",
         "ext-posix": "*"
     },
     "require": {


### PR DESCRIPTION
The SharedMemory and Semaphore classes require these extensions.

I would put them in required {}, but I kept it consistent and added them to the suggests {}
