### PR TITLE
Automatically create shared memory on demand

### DIFF
--- a/src/Ko/Process.php
+++ b/src/Ko/Process.php
@@ -64,6 +64,10 @@ class Process
      */
     public function getSharedMemory()
     {
+        if ($this->sharedMemory === null) {
+            $this->setSharedMemory(new SharedMemory());
+        }
+
         return $this->sharedMemory;
     }
 

--- a/src/Ko/ProcessManager.php
+++ b/src/Ko/ProcessManager.php
@@ -151,7 +151,6 @@ class ProcessManager implements \Countable
     protected function createProcess(callable $callable)
     {
         $p = new Process($callable);
-        $p->setSharedMemory(new SharedMemory());
         $p->on('exit', function ($pid) use ($p) {
             $this->childProcessDie($pid, $p->getStatus());
         });


### PR DESCRIPTION
It didn't seem necessary to creating the shared memory on every Process instance.
Also the new array access methods from #5 need to ensure a SharedMemory instance is available, which couldn't previously be gauranteed if the Process() class was instantiated by anything other than the ProcessManager
