### PR TITLE
Improvements and bug fixes to SharedMemory and Semaphore

### DIFF
--- a/src/Ko/Semaphore.php
+++ b/src/Ko/Semaphore.php
@@ -69,7 +69,7 @@ class Semaphore
     }
 
     /**
-     * Return TRUE is semaphore acquired.
+     * Return TRUE if semaphore acquired in this process.
      *
      * @return boolean
      */
@@ -99,9 +99,9 @@ class Semaphore
      */
     public function lockExecute(callable $callable)
     {
-        $this->acquire();
+        $this->isAcquired = $this->acquire();
         $result = $callable();
-        $this->release();
+        $this->isAcquired = $this->release();
 
         return $result;
     }

--- a/src/Ko/SharedMemory.php
+++ b/src/Ko/SharedMemory.php
@@ -45,7 +45,7 @@ class SharedMemory implements \ArrayAccess, \Countable
         }
 
         //Keymapper (maps mixed to integers)
-        shm_put_var($this->id, 0, []) ;
+        shm_put_var($this->id, 0, []);
         $this->mutex = new Semaphore($key);
     }
 
@@ -86,42 +86,41 @@ class SharedMemory implements \ArrayAccess, \Countable
     {
         $task = function() use ($offset) {
             return shm_has_var($this->id, $this->getKey($offset));
-        } ;
+        };
 
-        if($this->mutex->isAcquired())
-            return $task() ;
-        else
-            return $this->mutex->lockExecute($task) ;
+        return $this->mutex->lockExecute($task);
     }
     
     public function getKeys()
     {
-        return array_keys($this->getKeyMap()) ;
+        return array_keys($this->getKeyMap());
     }
 
     protected function getKeyMap()
     {
         $task = function() {
-            return shm_get_var($this->id, 0) ;
-        } ;
+            return shm_get_var($this->id, 0);
+        };
         
-        return $this->lockExecute($task) ;
+        return $this->lockExecute($task);
     }
     
     protected function getKey($offset)
     {
-        $keyMapper = $this->getKeyMap() ;
+        $keyMapper = $this->getKeyMap();
         if (isset($keyMapper[$offset])) {
             return $keyMapper[$offset];
         }
 
         //Get the next available integer for shm
-        if(count($keyMapper) > 0)
-            $keyMapper[$offset] = max($keyMapper)+1 ;
-        else
-            $keyMapper[$offset] = 1 ;
+        if(count($keyMapper) > 0) {
+            $keyMapper[$offset] = max($keyMapper)+1;
+        }
+        else {
+            $keyMapper[$offset] = 1;
+        }
         shm_put_var($this->id, 0, $keyMapper);
-        return $keyMapper[$offset] ;
+        return $keyMapper[$offset];
     }
 
     /**
@@ -144,9 +143,9 @@ class SharedMemory implements \ArrayAccess, \Countable
             }
 
             return null;
-        } ;
+        };
 
-        return $this->lockExecute($task) ;
+        return $this->lockExecute($task);
     }
 
     /**
@@ -167,9 +166,9 @@ class SharedMemory implements \ArrayAccess, \Countable
     {
         $task = function() use ($offset,$value) {
             shm_put_var($this->id, $this->getKey($offset), $value);
-        } ;
+        };
 
-        $this->lockExecute($task) ;
+        $this->lockExecute($task);
     }
 
     /**
@@ -186,15 +185,15 @@ class SharedMemory implements \ArrayAccess, \Countable
     public function offsetUnset($offset)
     {
         $task = function() use ($offset) {
-            $keyMapper = $this->getKeyMap() ;
+            $keyMapper = $this->getKeyMap();
             if(array_key_exists($offset,$keyMapper)) {
-                shm_remove_var($this->id, $keyMapper[$offset]) ;
-                unset($keyMapper[$offset]) ;
+                shm_remove_var($this->id, $keyMapper[$offset]);
+                unset($keyMapper[$offset]);
                 shm_put_var($this->id, 0, $keyMapper);
             }
-        } ;
+        };
         
-        $this->lockExecute($task) ;
+        $this->lockExecute($task);
     }
 
     /**
@@ -210,9 +209,9 @@ class SharedMemory implements \ArrayAccess, \Countable
     {
         $task = function() {
             return count($this->getKeyMap());
-        } ;
+        };
         
-        return $this->lockExecute($task) ;
+        return $this->lockExecute($task);
     }
     
     /**
@@ -224,10 +223,11 @@ class SharedMemory implements \ArrayAccess, \Countable
      */
     protected function lockExecute($task)
     {
-        if($this->mutex->isAcquired())
-            return $task() ;
-        else
-            return $this->mutex->lockExecute($task) ;
+        if($this->mutex->isAcquired()) {
+            return $task();
+        }
+
+        return $this->mutex->lockExecute($task);
     }
     
     /**
@@ -237,7 +237,7 @@ class SharedMemory implements \ArrayAccess, \Countable
      */
     public function lock()
     {
-        return $this->mutex->acquire() ;
+        return $this->mutex->acquire();
     }
     
     /**
@@ -247,6 +247,6 @@ class SharedMemory implements \ArrayAccess, \Countable
      */
     public function release()
     {
-        return $this->mutex->release() ;
+        return $this->mutex->release();
     }
 }

--- a/tests/Ko/SharedMemoryTest.php
+++ b/tests/Ko/SharedMemoryTest.php
@@ -54,4 +54,34 @@ class SharedMemoryTest extends \PHPUnit_Framework_TestCase
         unset($sm['test']);
         $this->assertCount(0, $sm);
     }
+    
+    public function testGetKeys()
+    {
+        $sm = new SharedMemory();
+        
+        $sm['test1'] = 'value1';
+        $sm['test2'] = 'value2';
+        $this->assertEquals(array('test1','test2'),$sm->getKeys());
+        
+        unset($sm['test1']);
+        
+        $this->assertEquals(array('test2'),$sm->getKeys());
+    }
+    
+    public function testLockAndRelease()
+    {
+        $sm = new SharedMemory();
+        $sm['test1'] = 'value1';
+        
+        $sm->lock();
+        
+        $this->assertEquals('value1',$sm['test1']);
+
+        $sm['test2'] = $sm['test1'] . "+value2";
+        
+        $sm->release();
+        
+        $this->assertEquals('value1+value2',$sm['test2']);
+    }
+    
 }


### PR DESCRIPTION
Hey Nikolay,

Am using your shared memory implementation in another project, and found a bug, plus added a few features necessary for my project.  

Just sharing back with you.  Haven't issued a pull request via github before, so hopefully I have done everything correctly.  Hope this proves useful.

Regards,
Damien.

SharedMemory.php
. The SharedMemory implementation had a flaw where in the keyMapper instance variable which maps non-numeric keys for the array backed by shared memory to an integer which can be used by the Sys V shm implementation.  This variable is not stored in the shared memory segment, thus each process accessing the shared memory has its own copy.  This results in duplicates arising in the shared memory for the same key if different processes attempt to create the same key in the shared memory.

This keyMapping array is now stored in index 0 of the shared memory and thus shared by all processes accessing the shared memory.

. Added the ability to use the mutex instance inside the SharedMemory object externally, so that non-atomic operations on the shared memory (such as performing a lookup to see if a key exists before adding something for that key) can be performed without creating race conditions.  So now there is a lock method for SharedMemory which will lock the shared memory, multiple accesses can occur, and then the release method can be called which unlocks the shared memory.

To implement the above feature, changes were made to SharedMemory's internal locking mechanism with the mutex by checking first to see if the Semaphore has already acquired the lock (in this process) before attempting to lock it again.  Locking again would could deadlock.

. Added method to SharedMemory so that getKeys returns just the array keys of the SharedMemory object.  Provides same result as calling array_keys function on an array.

A new protected method was created to replace getKeys for internal use called getKeyMap.  getKeyMap returns the entire key=>value array as is used internally by SharedMemory.

Semaphore.php
Ensure that the lockExecute method actually updates the isAcquired instance variable during its call so that calls to this method by SharedMemory will know that it is already locked and not attempt to lock again.