### PR TITLE
ProcessManager - emit shutdown after kill childrens

### DIFF
--- a/src/Ko/ProcessManager.php
+++ b/src/Ko/ProcessManager.php
@@ -110,11 +110,12 @@ class ProcessManager implements \Countable
     public function handleSigTerm()
     {
         $this->sigTerm = true;
-        $this->internalEmit('shutdown');
 
         foreach ($this->children as $process) {
             $process->kill();
         }
+        
+        $this->internalEmit('shutdown');
     }
 
     protected function childProcessDie($pid, $status)


### PR DESCRIPTION
Hey!

I suggest to put emit `shutdown` under the killing of childrens process
Your example is not killing childrens via It exists before killing

```php
        $manager->onShutdown(function() use ($manager) {
            echo 'Catch sigterm.Quiting...' . PHP_EOL;
            exit(1);
        });
```

Because you program will exit before, without killing childrens, It's rly bad

Thanks :cake: 